### PR TITLE
fix code issues

### DIFF
--- a/config/file_parser.go
+++ b/config/file_parser.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/goliatone/go-errors"
 	"github.com/knadh/koanf/parsers/json"
@@ -56,7 +57,7 @@ const (
 
 func inferConfigFiletype(path string, defaultFileType ...ConfigFileType) ConfigFileType {
 	ext := filepath.Ext(path)
-	switch ext {
+	switch strings.ToLower(ext) {
 	case ".toml":
 		return FileTypeTOML
 	case ".json":

--- a/config/manager.go
+++ b/config/manager.go
@@ -92,12 +92,16 @@ func New[C Validable](c C) *Container[C] {
 		},
 	}
 
-	mgr.K = koanf.NewWithConf(koanf.Conf{
-		Delim:       mgr.delimiter,
-		StrictMerge: mgr.strictMerge,
-	})
+	mgr.newConfig()
 
 	return mgr
+}
+
+func (c *Container[C]) newConfig() {
+	c.K = koanf.NewWithConf(koanf.Conf{
+		Delim:       c.delimiter,
+		StrictMerge: c.strictMerge,
+	})
 }
 
 func (c *Container[C]) Validate() error {
@@ -132,6 +136,9 @@ func (c *Container[C]) MustLoad(ctx context.Context) {
 func (c *Container[C]) Load(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, c.loadTimeout)
 	defer cancel()
+
+	// reset config state i.e. so if we remove keys the are gone
+	c.newConfig()
 
 	if len(c.loaders) > 0 {
 		c.providers = nil

--- a/config/merge_values.go
+++ b/config/merge_values.go
@@ -1,9 +1,5 @@
 package config
 
-// func MergeDefaultValues(def map[string]any) error {
-
-// }
-
 func MergeIgnoringNullValues(src, dest map[string]any) error {
 	for k, v := range src {
 		dv, ok := dest[k]

--- a/config/providers.go
+++ b/config/providers.go
@@ -3,7 +3,9 @@ package config
 import (
 	"context"
 	goerrors "errors"
+	"os"
 	"strings"
+	"syscall"
 
 	"github.com/goliatone/go-config/koanf/providers/env"
 	"github.com/goliatone/go-errors"
@@ -256,7 +258,8 @@ func DefaultErrorFilter(allowedErrors ...error) ErrorFilter {
 		}
 
 		if len(allowedErrors) == 0 {
-			return true
+			// ignore absent files but surface other errors i.e. JSON parsing blow up
+			return os.IsNotExist(err) || goerrors.Is(err, syscall.ENOENT)
 		}
 
 		for _, allowed := range allowedErrors {
@@ -264,6 +267,7 @@ func DefaultErrorFilter(allowedErrors ...error) ErrorFilter {
 				return true
 			}
 		}
+
 		return false
 	}
 }

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -38,9 +38,7 @@ func (c App) Validate() error {
 
 func main() {
 	app := &App{}
-	config := config.New(app).
-		WithProvider(config.EnvProvider[*App]("APP_", "__")).
-		WithProvider(config.FileProvider[*App]("./config/app.json"))
+	config := config.New(app)
 
 	ctx := context.Background()
 

--- a/koanf/providers/env/env2json.go
+++ b/koanf/providers/env/env2json.go
@@ -61,6 +61,7 @@ func ProviderWithValue(prefix, delim string, cb func(key string, value string) (
 		prefix: prefix,
 		delim:  delim,
 		cb:     cb,
+		out:    "{}",
 		logger: &logger.DefaultLogger{},
 	}
 }

--- a/koanf/providers/env/env2json_test.go
+++ b/koanf/providers/env/env2json_test.go
@@ -190,7 +190,7 @@ func TestProviderWithValue(t *testing.T) {
 	setEnv(t, "TEST_DATABASE__PASSWORD", "password")
 	defer unsetEnv(t, "TEST_DATABASE__PASSWORD")
 
-	provider := ProviderWithValue("TEST_", "__", func(key string, value string) (string, interface{}) {
+	provider := ProviderWithValue("TEST_", "__", func(key string, value string) (string, any) {
 		return strings.ToLower(strings.Replace(key, "TEST_", "", 1)), []string{value}
 	})
 	data, err := provider.ReadBytes()

--- a/koanf/solvers/uri_test.go
+++ b/koanf/solvers/uri_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestKSolver_base64(t *testing.T) {
-	defaultValues := map[string]interface{}{
+	defaultValues := map[string]any{
 		"password": "@base64://I3B3MTI7UmFkZCRhLjI0Mw==",
 	}
 
@@ -34,7 +34,7 @@ func TestKSolver_base64(t *testing.T) {
 
 func TestKSolver_URLs(t *testing.T) {
 	notMatching := "@file://nothing"
-	defaultValues := map[string]interface{}{
+	defaultValues := map[string]any{
 		"version": "@file://testdata/version.txt",
 		"context": map[string]any{
 			"version": "${version}",
@@ -71,7 +71,7 @@ func TestKSolver_URLs(t *testing.T) {
 
 func TestKSolver_URLs_with_fs(t *testing.T) {
 	notMatching := "@file://nothing"
-	defaultValues := map[string]interface{}{
+	defaultValues := map[string]any{
 		"version": "@file://testdata/version.txt",
 		"context": map[string]any{
 			"version": "${version}",

--- a/koanf/solvers/variables.go
+++ b/koanf/solvers/variables.go
@@ -42,18 +42,17 @@ func (s variables) keypath(key, val string, config *koanf.Koanf) {
 		return
 	}
 
-	if len(s.delimeters.Start) > 1 {
-		start = start + len(s.delimeters.Start)
-	}
+	contentStart := start + len(s.delimeters.Start)
 
-	end := strings.Index(val[start:], s.delimeters.End)
-	if end == -1 || end < start {
+	endOffset := strings.Index(val[contentStart:], s.delimeters.End)
+	if endOffset == -1 {
 		return
 	}
-	end = end + len(s.delimeters.Start)
 
-	path := val[start:end]
-	if path == val {
+	contentEnd := contentStart + endOffset
+
+	path := val[contentStart:contentEnd]
+	if path == "" || path == val {
 		return
 	}
 

--- a/koanf/solvers/variables.go
+++ b/koanf/solvers/variables.go
@@ -37,35 +37,52 @@ func (s variables) Solve(config *koanf.Koanf) *koanf.Koanf {
 }
 
 func (s variables) keypath(key, val string, config *koanf.Koanf) {
-	start := strings.Index(val, s.delimeters.Start)
-	if start == -1 {
-		return
+	current := val
+
+	for {
+		start := strings.Index(current, s.delimeters.Start)
+		if start == -1 {
+			break
+		}
+
+		contentStart := start + len(s.delimeters.Start)
+		endOffset := strings.Index(current[contentStart:], s.delimeters.End)
+		if endOffset == -1 {
+			break
+		}
+
+		contentEnd := contentStart + endOffset
+		path := current[contentStart:contentEnd]
+		if path == "" || path == key {
+			break
+		}
+
+		if !config.Exists(path) {
+			break
+		}
+
+		resolved := config.Get(path)
+		isFullMatch := start == 0 && contentEnd+len(s.delimeters.End) == len(current)
+
+		if isFullMatch {
+			if key == path {
+				break
+			}
+			config.Set(key, resolved)
+			return
+		}
+
+		next := s.replaceValue(current, resolved)
+		if next == current {
+			break
+		}
+
+		current = next
 	}
 
-	contentStart := start + len(s.delimeters.Start)
-
-	endOffset := strings.Index(val[contentStart:], s.delimeters.End)
-	if endOffset == -1 {
-		return
+	if current != val {
+		config.Set(key, current)
 	}
-
-	contentEnd := contentStart + endOffset
-
-	path := val[contentStart:contentEnd]
-	if path == "" || path == val {
-		return
-	}
-
-	if !config.Exists(path) {
-		return
-	}
-
-	newVal := config.Get(path)
-	if len(s.delimeters.Start)+len(path)+len(s.delimeters.End) != len(val) {
-		newVal = s.replaceValue(val, newVal)
-	}
-
-	config.Set(key, newVal)
 }
 
 func (s variables) replaceValue(input string, replacement any) string {

--- a/koanf/solvers/variables_test.go
+++ b/koanf/solvers/variables_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestKSolver_Variables(t *testing.T) {
 	notMatching := "${nothing}"
-	defaultValues := map[string]interface{}{
+	defaultValues := map[string]any{
 		"server": map[string]any{
 			"base_url": "${base_url}",
 		},
@@ -49,7 +49,7 @@ func TestKSolver_Variables(t *testing.T) {
 
 func TestKSolver_Variables_custom_delimeters(t *testing.T) {
 	notMatching := "@/nothing/"
-	defaultValues := map[string]interface{}{
+	defaultValues := map[string]any{
 		"server": map[string]any{
 			"base_url": "@/base_url/",
 		},
@@ -88,7 +88,7 @@ func TestKSolver_Variables_custom_delimeters(t *testing.T) {
 
 func TestKSolver_Variables_custom_delimeters2(t *testing.T) {
 	notMatching := "{{nothing}}"
-	defaultValues := map[string]interface{}{
+	defaultValues := map[string]any{
 		"server": map[string]any{
 			"base_url": "{{base_url}}",
 		},
@@ -127,7 +127,7 @@ func TestKSolver_Variables_custom_delimeters2(t *testing.T) {
 
 func TestKSolver_Variables_non_matching(t *testing.T) {
 	notMatching := "${nothing}"
-	defaultValues := map[string]interface{}{
+	defaultValues := map[string]any{
 		"server": map[string]any{
 			"base_url": "${base_url}",
 		},
@@ -162,4 +162,22 @@ func TestKSolver_Variables_non_matching(t *testing.T) {
 		notMatching,
 		out.Get("not_matching"),
 	)
+}
+
+func TestKSolver_Variables_embedded(t *testing.T) {
+	defaultValues := map[string]any{
+		"host": "localhost",
+		"lang": "en",
+		"server": map[string]any{
+			"endpoint": "http://${host}/api/v0/${lang}",
+		},
+	}
+
+	k := koanf.New(".")
+	k.Load(confmap.Provider(defaultValues, "."), nil)
+
+	solver := NewVariablesSolver("${", "}")
+	out := solver.Solve(k)
+
+	assert.Equal(t, "http://localhost/api/v0/en", out.Get("server.endpoint"))
 }


### PR DESCRIPTION
This PR solves different code issues
- fix: normalize file name to lowercase so we support `config/APP.YAML` and `config/app.yaml`
- fix: reset config state on each call to Load so that we can pickup changes
- fix: default error filter will now catch errors and ignore absent files
- fix: variable solver key index bug
- fix: variable solver handle multi value placeholders
- fix: env2json `ProviderWithValue` should have empty object as default (vs nil)